### PR TITLE
Faster formatting

### DIFF
--- a/src/httpdate.rs
+++ b/src/httpdate.rs
@@ -40,39 +40,67 @@ impl HttpDate {
 
 impl From<SystemTime> for HttpDate {
     fn from(v: SystemTime) -> HttpDate {
-        let secs_since_epoch = v.duration_since(UNIX_EPOCH)
-            .expect("all times should be after the epoch")
-            .as_secs();
-        let mut days = secs_since_epoch / 86400;
-        let wday = ((days + 3) % 7) + 1;
+        let dur = v.duration_since(UNIX_EPOCH)
+            .expect("all times should be after the epoch");
+        let secs_since_epoch = dur.as_secs();
+
+        if secs_since_epoch >= 253402300800 { // year 9999
+            panic!("date must be before year 9999");
+        }
+
+        /* 2000-03-01 (mod 400 year, immediately after feb29 */
+        const LEAPOCH: i64 = 11017;
+        const DAYS_PER_400Y: i64 = 365*400 + 97;
+        const DAYS_PER_100Y: i64 = 365*100 + 24;
+        const DAYS_PER_4Y: i64 = 365*4 + 1;
+
+        let days = (secs_since_epoch / 86400) as i64 - LEAPOCH;
         let secs_of_day = secs_since_epoch % 86400;
-        let mut year = 1970;
-        loop {
-            let ydays = if is_leap_year(year) {
-                366
-            } else {
-                365
-            };
-            if days >= ydays {
-                days -= ydays;
-                year += 1;
-            } else {
-                break;
-            }
+
+        let mut qc_cycles = days / DAYS_PER_400Y;
+        let mut remdays = days % DAYS_PER_400Y;
+
+        if remdays < 0 {
+            remdays += DAYS_PER_400Y;
+            qc_cycles -= 1;
         }
-        let mut months = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-        if is_leap_year(year) {
-            months[1] += 1;
-        }
+
+        let mut c_cycles = remdays / DAYS_PER_100Y;
+        if c_cycles == 4 { c_cycles -= 1; }
+        remdays -= c_cycles * DAYS_PER_100Y;
+
+        let mut q_cycles = remdays / DAYS_PER_4Y;
+        if q_cycles == 25 { q_cycles -= 1; }
+        remdays -= q_cycles * DAYS_PER_4Y;
+
+        let mut remyears = remdays / 365;
+        if remyears == 4 { remyears -= 1; }
+        remdays -= remyears * 365;
+
+        let mut year = 2000 +
+            remyears + 4*q_cycles + 100*c_cycles + 400*qc_cycles;
+
+        let months = [31,30,31,30,31,31,30,31,30,31,31,29];
         let mut mon = 0;
         for mon_len in months.iter() {
             mon += 1;
-            if days < *mon_len {
+            if remdays < *mon_len {
                 break;
             }
-            days -= *mon_len;
+            remdays -= *mon_len;
         }
-        let mday = days + 1;
+        let mday = remdays+1;
+        let mon = if mon + 2 > 12 {
+            year += 1;
+            mon - 10
+        } else {
+            mon + 2
+        };
+
+        let mut wday = (3+days)%7;
+        if wday <= 0 {
+            wday += 7
+        };
 
         HttpDate {
             sec: (secs_of_day % 60) as u8,
@@ -80,7 +108,7 @@ impl From<SystemTime> for HttpDate {
             hour: (secs_of_day / 3600) as u8,
             day: mday as u8,
             mon: mon as u8,
-            year: year,
+            year: year as u16,
             wday: wday as u8,
         }
     }

--- a/src/httpdate.rs
+++ b/src/httpdate.rs
@@ -162,38 +162,58 @@ impl FromStr for HttpDate {
 
 impl Display for HttpDate {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{wday}, {day:02} {mon} {year} {hour:02}:{min:02}:{sec:02} GMT",
-            sec=self.sec,
-            min=self.min,
-            hour=self.hour,
-            day=self.day,
-            mon=match self.mon {
-                1 => "Jan",
-                2 => "Feb",
-                3 => "Mar",
-                4 => "Apr",
-                5 => "Mai",
-                6 => "Jun",
-                7 => "Jul",
-                8 => "Aug",
-                9 => "Sep",
-                10 => "Oct",
-                11 => "Nov",
-                12 => "Dec",
-                _ => unreachable!(),
-            },
-            year=self.year,
-            wday=match self.wday {
-                1 => "Mon",
-                2 => "Tue",
-                3 => "Wed",
-                4 => "Thu",
-                5 => "Fri",
-                6 => "Sat",
-                7 => "Sun",
-                _ => unreachable!(),
-            },
-        )
+        let wday = match self.wday {
+            1 => b"Mon",
+            2 => b"Tue",
+            3 => b"Wed",
+            4 => b"Thu",
+            5 => b"Fri",
+            6 => b"Sat",
+            7 => b"Sun",
+            _ => unreachable!(),
+        };
+        let mon = match self.mon {
+            1 => b"Jan",
+            2 => b"Feb",
+            3 => b"Mar",
+            4 => b"Apr",
+            5 => b"Mai",
+            6 => b"Jun",
+            7 => b"Jul",
+            8 => b"Aug",
+            9 => b"Sep",
+            10 => b"Oct",
+            11 => b"Nov",
+            12 => b"Dec",
+            _ => unreachable!(),
+        };
+        let mut buf: [u8; 29] = [
+            // Too long to write as: b"Thu, 01 Jan 1970 00:00:00 GMT"
+            b' ', b' ', b' ', b',', b' ',
+            b'0', b'0', b' ', b' ', b' ', b' ', b' ',
+            b'0', b'0', b'0', b'0', b' ',
+            b'0', b'0', b':', b'0', b'0', b':', b'0', b'0',
+            b' ', b'G', b'M', b'T',
+        ];
+        buf[0] = wday[0];
+        buf[1] = wday[1];
+        buf[2] = wday[2];
+        buf[5] = b'0' + (self.day / 10) as u8;
+        buf[6] = b'0' + (self.day % 10) as u8;
+        buf[8] = mon[0];
+        buf[9] = mon[1];
+        buf[10] = mon[2];
+        buf[12] = b'0' + (self.year / 1000) as u8;
+        buf[13] = b'0' + (self.year / 100 % 10) as u8;
+        buf[14] = b'0' + (self.year / 10 % 10) as u8;
+        buf[15] = b'0' + (self.year % 10) as u8;
+        buf[17] = b'0' + (self.hour / 10) as u8;
+        buf[18] = b'0' + (self.hour % 10) as u8;
+        buf[20] = b'0' + (self.min / 10) as u8;
+        buf[21] = b'0' + (self.min % 10) as u8;
+        buf[23] = b'0' + (self.sec / 10) as u8;
+        buf[24] = b'0' + (self.sec % 10) as u8;
+        f.write_str(unsafe { from_utf8_unchecked(&buf[..]) })
     }
 }
 


### PR DESCRIPTION
This PR improves performance of formatting httpdate so that it's now on par with recent humantime.

Before the change:
```
test format ... bench:         283 ns/iter (+/- 57)
```

After the change:
```
test format ... bench:          74 ns/iter (+/- 1)
```

The math imported from musl libc. And you might want to put a [similar acknowledge](https://github.com/tailhook/humantime/blob/master/LICENSE-MIT#L6-L7).

Also, I've just run `cargo test` it seems to contain small number of tests. I haven't tried fuzzing (not familiar with the tool, may try later). Math is tested quite well in humantime so should be okay.