### PR TITLE
Derive Hash for HttpDate

### DIFF
--- a/src/httpdate.rs
+++ b/src/httpdate.rs
@@ -13,7 +13,7 @@ use Error;
 /// Format using the `Display` trait.
 /// Convert timestamp into/from `SytemTime` to use.
 /// Supports comparsion and sorting.
-#[derive(Copy, Clone, Debug, Eq, Ord)]
+#[derive(Copy, Clone, Debug, Eq, Ord, Hash)]
 pub struct HttpDate {
     /// 0...59
     sec: u8,


### PR DESCRIPTION
The headers crate has expressed interest in using httpdate[1], but it needs
`Hash` to be implemented on its `HttpDate` facade.

[1]: https://github.com/hyperium/headers/pull/74