### PR TITLE
Add failing test of HttpDate equality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub fn fmt_http_date(d: SystemTime) -> String {
 #[cfg(test)]
 mod tests {
     use std::str;
-    use std::time::{Duration, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use super::{fmt_http_date, parse_http_date, HttpDate};
 
@@ -148,5 +148,15 @@ mod tests {
         let b_date: HttpDate = b.into();
         assert!(a_date < b_date);
         assert_eq!(a_date.cmp(&b_date), ::std::cmp::Ordering::Less)
+    }
+
+    #[test]
+    fn test_date_equality() {
+        let nov_07_sys = UNIX_EPOCH + Duration::new(784198117, 0);
+        let nov_07 = nov_07_sys.into();
+        let parsed = "Sun, 07 Nov 1994 08:48:37 GMT".parse::<HttpDate>().unwrap();
+        let parsed_sys: SystemTime = parsed.into();
+        assert_eq!(parsed_sys, nov_07_sys);
+        assert_eq!(parsed, nov_07);
     }
 }


### PR DESCRIPTION
On attempting to upgrade to 1.0.0 I found a strange change in behavior. This is a minimal reproduction in the form of a failing test. On 1.0.0 the test fails on the last assert with the following:

```txt
thread 'tests::test_date_equality' panicked at 'assertion failed: `(left == right)`
  left: `HttpDate { sec: 37, min: 48, hour: 8, day: 7, mon: 11, year: 1994, wday: 7 }`,
 right: `HttpDate { sec: 37, min: 48, hour: 8, day: 7, mon: 11, year: 1994, wday: 1 }`', src/lib.rs:160:9
```
Note that the prior assert using `SystemTime` equality does not fail. 

Also if I backport the test to 0.3.2, it passes.



