### PR TITLE
feat: Add ability to convert seconds(u64) to HttpDate

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -42,15 +42,7 @@ impl HttpDate {
             && self.year <= 9999
             && &HttpDate::from(SystemTime::from(*self)) == self
     }
-}
-
-impl From<SystemTime> for HttpDate {
-    fn from(v: SystemTime) -> HttpDate {
-        let dur = v
-            .duration_since(UNIX_EPOCH)
-            .expect("all times should be after the epoch");
-        let secs_since_epoch = dur.as_secs();
-
+    pub fn from_secs_since_epoch(secs_since_epoch: u64) -> Self {
         if secs_since_epoch >= 253402300800 {
             // year 9999
             panic!("date must be before year 9999");
@@ -124,6 +116,16 @@ impl From<SystemTime> for HttpDate {
             year: year as u16,
             wday: wday as u8,
         }
+    }
+}
+
+impl From<SystemTime> for HttpDate {
+    fn from(v: SystemTime) -> HttpDate {
+        let dur = v
+            .duration_since(UNIX_EPOCH)
+            .expect("all times should be after the epoch");
+        let secs_since_epoch = dur.as_secs();
+        Self::from_secs_since_epoch(secs_since_epoch)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,4 +157,10 @@ mod tests {
         let parsed = "Sun, 07 Nov 1994 08:48:37 GMT".parse::<HttpDate>();
         assert!(parsed.is_err())
     }
+
+    #[test]
+    fn test_from_secs_since_epoch() {
+        let ts = 1666206668;
+        assert_eq!(HttpDate::from_secs_since_epoch(ts).to_string(), "Wed, 19 Oct 2022 19:11:08 GMT");
+    }
 }


### PR DESCRIPTION
Sometimes `SystemTime` cannot be obtained, and instead just plain timestamp is the only thing available. For example, using this with `rust-embed` is one of those cases.

This change:
 - Adds `from_secs_since_epoch` that allows conversion from `u64` to `HttpDate`, didn't use `From<u64>` trait, so it's clear what unit is expected there.
 - Switched `From<SystemTime>` to use that new method underneath.  