### PR TITLE
Add `TryFrom<&[u8]>` implementation for HttpDate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,57 +63,72 @@ pub fn fmt_http_date(d: SystemTime) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::str;
-    use std::time::{Duration, UNIX_EPOCH};
+    use std::convert::TryFrom;
+    use std::str::FromStr;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-    use super::{fmt_http_date, parse_http_date, HttpDate};
+    use super::{fmt_http_date, HttpDate};
+
+    /// Test that parsing via parse_http_date, from_str and try_parse gives the
+    /// same result and then returns the result.
+    fn parse(value: &str) -> Result<SystemTime, super::Error> {
+        let res1 = super::parse_http_date(value);
+        let res2 = super::HttpDate::from_str(value);
+        let res3 = super::HttpDate::try_from(value.as_bytes());
+        assert!(
+            res1.is_ok() == res2.is_ok() && res2.is_ok() == res3.is_ok(),
+            "{:?} vs {:?} vs {:?}; value: {}",
+            res1,
+            res2,
+            res3,
+            value
+        );
+        if res1.is_err() {
+            return res1;
+        }
+        let (res1, res2, res3) = (res1.unwrap(), res2.unwrap(), res3.unwrap());
+        assert_eq!(res2, res3, "value: {}", value);
+        assert_eq!(res1, SystemTime::from(res2), "value: {}", value);
+        Ok(res1)
+    }
 
     #[test]
     fn test_rfc_example() {
         let d = UNIX_EPOCH + Duration::from_secs(784111777);
-        assert_eq!(
-            d,
-            parse_http_date("Sun, 06 Nov 1994 08:49:37 GMT").expect("#1")
-        );
-        assert_eq!(
-            d,
-            parse_http_date("Sunday, 06-Nov-94 08:49:37 GMT").expect("#2")
-        );
-        assert_eq!(d, parse_http_date("Sun Nov  6 08:49:37 1994").expect("#3"));
+        assert_eq!(d, parse("Sun, 06 Nov 1994 08:49:37 GMT").expect("#1"));
+        assert_eq!(d, parse("Sunday, 06-Nov-94 08:49:37 GMT").expect("#2"));
+        assert_eq!(d, parse("Sun Nov  6 08:49:37 1994").expect("#3"));
     }
 
     #[test]
     fn test2() {
         let d = UNIX_EPOCH + Duration::from_secs(1475419451);
-        assert_eq!(
-            d,
-            parse_http_date("Sun, 02 Oct 2016 14:44:11 GMT").expect("#1")
-        );
-        assert!(parse_http_date("Sun Nov 10 08:00:00 1000").is_err());
-        assert!(parse_http_date("Sun Nov 10 08*00:00 2000").is_err());
-        assert!(parse_http_date("Sunday, 06-Nov-94 08+49:37 GMT").is_err());
+        assert_eq!(d, parse("Sun, 02 Oct 2016 14:44:11 GMT").expect("#1"));
+        assert!(parse("Sun Nov 10 08:00:00 1000").is_err());
+        assert!(parse("Sun Nov 10 08*00:00 2000").is_err());
+        assert!(parse("Sunday, 06-Nov-94 08+49:37 GMT").is_err());
     }
 
     #[test]
     fn test3() {
         let mut d = UNIX_EPOCH;
-        assert_eq!(d, parse_http_date("Thu, 01 Jan 1970 00:00:00 GMT").unwrap());
+        assert_eq!(d, parse("Thu, 01 Jan 1970 00:00:00 GMT").unwrap());
         d += Duration::from_secs(3600);
-        assert_eq!(d, parse_http_date("Thu, 01 Jan 1970 01:00:00 GMT").unwrap());
+        assert_eq!(d, parse("Thu, 01 Jan 1970 01:00:00 GMT").unwrap());
         d += Duration::from_secs(86400);
-        assert_eq!(d, parse_http_date("Fri, 02 Jan 1970 01:00:00 GMT").unwrap());
+        assert_eq!(d, parse("Fri, 02 Jan 1970 01:00:00 GMT").unwrap());
         d += Duration::from_secs(2592000);
-        assert_eq!(d, parse_http_date("Sun, 01 Feb 1970 01:00:00 GMT").unwrap());
+        assert_eq!(d, parse("Sun, 01 Feb 1970 01:00:00 GMT").unwrap());
         d += Duration::from_secs(2592000);
-        assert_eq!(d, parse_http_date("Tue, 03 Mar 1970 01:00:00 GMT").unwrap());
+        assert_eq!(d, parse("Tue, 03 Mar 1970 01:00:00 GMT").unwrap());
         d += Duration::from_secs(31536005);
-        assert_eq!(d, parse_http_date("Wed, 03 Mar 1971 01:00:05 GMT").unwrap());
+        assert_eq!(d, parse("Wed, 03 Mar 1971 01:00:05 GMT").unwrap());
         d += Duration::from_secs(15552000);
-        assert_eq!(d, parse_http_date("Mon, 30 Aug 1971 01:00:05 GMT").unwrap());
+        assert_eq!(d, parse("Mon, 30 Aug 1971 01:00:05 GMT").unwrap());
         d += Duration::from_secs(6048000);
-        assert_eq!(d, parse_http_date("Mon, 08 Nov 1971 01:00:05 GMT").unwrap());
+        assert_eq!(d, parse("Mon, 08 Nov 1971 01:00:05 GMT").unwrap());
         d += Duration::from_secs(864000000);
-        assert_eq!(d, parse_http_date("Fri, 26 Mar 1999 01:00:05 GMT").unwrap());
+        assert_eq!(d, parse("Fri, 26 Mar 1999 01:00:05 GMT").unwrap());
     }
 
     #[test]
@@ -126,9 +141,9 @@ mod tests {
 
     #[allow(dead_code)]
     fn testcase(data: &[u8]) {
-        if let Ok(s) = str::from_utf8(data) {
+        if let Ok(s) = std::str::from_utf8(data) {
             println!("{:?}", s);
-            if let Ok(d) = parse_http_date(s) {
+            if let Ok(d) = parse(s) {
                 let o = fmt_http_date(d);
                 assert!(!o.is_empty());
             }


### PR DESCRIPTION
Parsing code works correctly if the input is not a valid UTF-8 string
thus it can be safely used with `&[u8]`.  This is allows users to
avoid performing UTF-8 verification when trying to parse the date.
