### PR TITLE
Change internals to use `datealgo` library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ criterion = "0.5"
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[dependencies]
+datealgo = "0.1.0"


### PR DESCRIPTION
Add a dependency to the `datealgo` library and use that to perform the internal date operations. There should be no observable change in functionality.

This improves performance somewhat significantly:
```
parse_imf_fixdate       time:   [31.105 ns 31.158 ns 31.216 ns]
                        change: [-46.943% -46.833% -46.725%] (p = 0.00 < 0.05)
                        Performance has improved.

parse_rfc850_date       time:   [29.666 ns 29.733 ns 29.806 ns]
                        change: [-47.462% -47.303% -47.146%] (p = 0.00 < 0.05)
                        Performance has improved.

parse_asctime           time:   [32.829 ns 32.890 ns 32.957 ns]
                        change: [-44.844% -44.712% -44.580%] (p = 0.00 < 0.05)
                        Performance has improved.

encode_date             time:   [8.4868 ns 8.5054 ns 8.5248 ns]
                        change: [-6.0120% -5.6846% -5.3694%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Disclaimer: I am the author of the `datealgo` library.